### PR TITLE
move URI for backend socket.io from frontend app into docker-compose …

### DIFF
--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -3,6 +3,10 @@ FROM node:12
 # Create app directory
 WORKDIR /usr/src/api
 
+# Pass through backend URI from docker-compose.yml to frontend app
+ARG REACT_APP_API_URI
+ENV REACT_APP_API_URI $REACT_APP_API_URI
+
 # Install app dependencies
 # For production, RUN npm ci --only=production
 COPY package*.json ./

--- a/dashboard/src/components/Layout.js
+++ b/dashboard/src/components/Layout.js
@@ -13,7 +13,7 @@ class Layout extends Component {
         this.state = {
             hpfeed: false,
             aggregates: false,
-            endpoint: 'http://127.0.0.1:3001'
+            endpoint: process.env.REACT_APP_API_URI
         };
     }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,8 @@ services:
         image: dashboard
         build:
             context: ./dashboard
+            args:
+                REACT_APP_API_URI: "<URL FOR SOCKET.IO IN SERVER.JS>"
         ports:
             - 8080:3000
         volumes:


### PR DESCRIPTION
…environment variable

This commit fixes an issue where the URI for the backend socket.io was hardcoded as a variable within the front-end dashboard code. This commit moves the declaration of this value to an environment variable within docker-compose.yml