### PR TITLE
Handle empty hashes from cowrie

### DIFF
--- a/api/server.js
+++ b/api/server.js
@@ -22,7 +22,7 @@ const getAggregates = data => {
     let total_urls = [].concat.apply([], url_collections).length /* Calculating total number of elements. Does not check if URL is unique or has been seen before */
     console.log(total_urls);
     let hash_collections = data.map(event => event.shasum).filter(hashes => hashes.length);
-    let total_hashes = [].concat.apply([], hash_collections).length
+    let total_hashes = [].concat.apply([], hash_collections).filter(string => {return string !== '';}).length;
     console.log(total_hashes);
     return {
         attacks: total_attacks,

--- a/dashboard/src/components/Event.js
+++ b/dashboard/src/components/Event.js
@@ -42,7 +42,7 @@ class Event extends Component {
                     <div>{ timestamp }</div>
                     <div>{ src_ip }</div>
                     <div className={ urls.length !== 0 ? 'highlight' : '' }>{ urls.length }</div>
-                    <div className={ hashes.length !== 0 ? 'highlight' : '' }>{ hashes.length }</div>
+                    <div className={ hashes.length !== 0 ? 'highlight' : '' }>{ hashes.filter(string => {return string !== '';}).length }</div>
                     <div>{ commands.length }</div>
                     <EventModal data={modal_props} toggle={this.toggle} />
             </div>


### PR DESCRIPTION
Found an issue with cowrie that curl will log an empty hash (i.e. `''`) for responses of `Content-Length: 0`. Looking into improving logging within cowrie for this situation but implemented checks for empty hash strings into the dashboard to ensure statistics aren't affected for now - could perhaps implement a check within the mongodb handling itself but not sure what the best level to do this check at is. 